### PR TITLE
Fix signing failures with Phantom Wallet 23.3.0+

### DIFF
--- a/src/lib/anchorUtils.ts
+++ b/src/lib/anchorUtils.ts
@@ -44,14 +44,20 @@ export const customProviderFactory = (
     tx.feePayer = anchorWallet?.publicKey;
     tx.recentBlockhash = (await connection.getRecentBlockhash()).blockhash;
 
-    await anchorWallet?.signTransaction(tx);
+    let signedTx = await anchorWallet?.signTransaction(tx);
+    if (signedTx === undefined) {
+      return '';
+    }
+    
     signers
       .filter((s): s is Signer => s !== undefined)
       .forEach((kp) => {
-        tx.partialSign(kp);
+        if (signedTx) {
+          signedTx.partialSign(kp);
+        }
       });
 
-    const rawTx = tx.serialize();
+    const rawTx = signedTx.serialize();
     const signature = await connection.sendRawTransaction(rawTx);
 
     // Await for 30 seconds


### PR DESCRIPTION
Makes transaction reassigning explicit. 

Beginning with the phantom 23.3.0 update, this re-assignment is now explicitly required.

Based on the following thread in Phantom discord for details:
https://discord.com/channels/958228318132514876/1086677537633091654/1087273616724480071